### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/amazon-corretto`
 
-The Paketo Amazon Corretto Buildpack is a Cloud Native Buildpack that provides the Amazon Corretto implementations of JREs and JDKs.
+The Paketo Buildpack for Amazon Corretto is a Cloud Native Buildpack that provides the Amazon Corretto implementations of JREs and JDKs.
 
 This buildpack is designed to work in collaboration with other buildpacks which request contributions of JREs and JDKs.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/amazon-corretto"
   id = "paketo-buildpacks/amazon-corretto"
   keywords = ["java", "jvm", "jre", "jdk"]
-  name = "Paketo Amazon Corretto Buildpack"
+  name = "Paketo Buildpack for Amazon Corretto"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Amazon Corretto Buildpack' to 'Paketo Buildpack for Amazon Corretto'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
