### PR TITLE
Remove Java 24 and add Java 25

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -49,13 +49,13 @@ dependencies:
   with:
     glob:       amazon-corretto-[\d.-]+-linux-x64.tar.gz
     repository: corretto-21
-- name:            JDK 24
+- name:            JDK 25
   id:              jdk
-  version_pattern: "24\\.[\\d]+\\.[\\d]+"
+  version_pattern: "25\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/amazon-corretto-dependency:main
   with:
     glob:       amazon-corretto-[\d.-]+-linux-x64.tar.gz
-    repository: corretto-24
+    repository: corretto-25
 
 # ARM64
 - name:            JDK 8 ARM64
@@ -91,11 +91,11 @@ dependencies:
     glob:       amazon-corretto-[\d.-]+-linux-aarch64.tar.gz
     repository: corretto-21
     arch: arm64
-- name:            JDK 24 ARM64
+- name:            JDK 25 ARM64
   id:              jdk
-  version_pattern: "24\\.[\\d]+\\.[\\d]+"
+  version_pattern: "25\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/amazon-corretto-dependency:main
   with:
     glob:       amazon-corretto-[\d.-]+-linux-aarch64.tar.gz
-    repository: corretto-24
+    repository: corretto-25
     arch: arm64

--- a/.github/workflows/pb-update-jdk-25-arm-64.yml
+++ b/.github/workflows/pb-update-jdk-25-arm-64.yml
@@ -1,4 +1,4 @@
-name: Update JDK 24 ARM64
+name: Update JDK 25 ARM64
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -29,7 +29,7 @@ jobs:
               with:
                 arch: arm64
                 glob: amazon-corretto-[\d.-]+-linux-aarch64.tar.gz
-                repository: corretto-24
+                repository: corretto-25
             - name: Update Buildpack Dependency
               id: buildpack
               run: |
@@ -87,18 +87,18 @@ jobs:
                 SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
-                VERSION_PATTERN: 24\.[\d]+\.[\d]+
+                VERSION_PATTERN: 25\.[\d]+\.[\d]+
             - uses: peter-evans/create-pull-request@v6
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `JDK 24 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/jdk-24-arm-64
+                body: Bumps `JDK 25 ARM64` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jdk-25-arm-64
                 commit-message: |-
-                    Bump JDK 24 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump JDK 25 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps JDK 24 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps JDK 25 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump JDK 24 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump JDK 25 ARM64 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-jdk-25.yml
+++ b/.github/workflows/pb-update-jdk-25.yml
@@ -1,4 +1,4 @@
-name: Update JDK 24
+name: Update JDK 25
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -28,7 +28,7 @@ jobs:
               uses: docker://ghcr.io/paketo-buildpacks/actions/amazon-corretto-dependency:main
               with:
                 glob: amazon-corretto-[\d.-]+-linux-x64.tar.gz
-                repository: corretto-24
+                repository: corretto-25
             - name: Update Buildpack Dependency
               id: buildpack
               run: |
@@ -86,18 +86,18 @@ jobs:
                 SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
-                VERSION_PATTERN: 24\.[\d]+\.[\d]+
+                VERSION_PATTERN: 25\.[\d]+\.[\d]+
             - uses: peter-evans/create-pull-request@v6
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `JDK 24` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/jdk-24
+                body: Bumps `JDK 25` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/jdk-25
                 commit-message: |-
-                    Bump JDK 24 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump JDK 25 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps JDK 24 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps JDK 25 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump JDK 24 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump JDK 25 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -203,16 +203,16 @@ api = "0.7"
       uri = "https://aws.amazon.com/corretto/faqs/#Licensing_and_Open_Source"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:jdk:24.0.2:*:*:*:*:*:*:*", "cpe:2.3:a:amazon:corretto:24.0.2:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:jdk:25.0.0:*:*:*:*:*:*:*", "cpe:2.3:a:amazon:corretto:25.0.0:*:*:*:*:*:*:*"]
     id = "jdk"
     name = "Corretto JDK"
-    purl = "pkg:generic/amazon/corretto-jdk@24.0.2?arch=amd64"
-    sha256 = "d4cd1f03a8b9aad58d0fdac96d1ba5de6b7ac86f3069729535f2fc1e5a33f7c6"
-    source = "https://github.com/corretto/corretto-24/archive/refs/tags/24.0.2.12.1.tar.gz"
-    source-sha256 = "68d30020cbea82d8e5768b4ffb1b236f46b172b6a8e4deee469e197703db62cc"
+    purl = "pkg:generic/amazon/corretto-jdk@25.0.0?arch=amd64"
+    sha256 = "7fa3a845e2a2197d01d875889597d4196e3da310c85a4687d4214a4161cdccd0"
+    source = "https://github.com/corretto/corretto-25/archive/refs/tags/25.0.0.36.2.tar.gz"
+    source-sha256 = "ac3d48650813180ec15deb1ac1fdc0e946c5e273447b87e62a1a15b8f66bae70"
     stacks = ["*"]
-    uri = "https://corretto.aws/downloads/resources/24.0.2.12.1/amazon-corretto-24.0.2.12.1-linux-x64.tar.gz"
-    version = "24.0.2"
+    uri = "https://corretto.aws/downloads/resources/25.0.0.36.2/amazon-corretto-25.0.0.36.2-linux-x64.tar.gz"
+    version = "25.0.0"
 
     [[metadata.dependencies.licenses]]
       type = "GPL-2.0 WITH Classpath-exception-2.0"
@@ -283,16 +283,16 @@ api = "0.7"
       uri = "https://aws.amazon.com/corretto/faqs/#Licensing_and_Open_Source"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:oracle:jdk:24.0.2:*:*:*:*:*:*:*", "cpe:2.3:a:amazon:corretto:24.0.2:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:oracle:jdk:25.0.0:*:*:*:*:*:*:*", "cpe:2.3:a:amazon:corretto:25.0.0:*:*:*:*:*:*:*"]
     id = "jdk"
     name = "Corretto JDK"
-    purl = "pkg:generic/amazon/corretto-jdk@24.0.2?arch=arm64"
-    sha256 = "57a5cdd6ba25dcf765390b3c8fcb085667fe3ef9cf6ccbc8e21f43cb5b40f267"
-    source = "https://github.com/corretto/corretto-24/archive/refs/tags/24.0.2.12.1.tar.gz"
-    source-sha256 = "68d30020cbea82d8e5768b4ffb1b236f46b172b6a8e4deee469e197703db62cc"
+    purl = "pkg:generic/amazon/corretto-jdk@25.0.0?arch=arm64"
+    sha256 = "9d25b07aff40d98b5fa6879ce4b31dd062a9c0a5283aacf42b2a1e41b61ae419"
+    source = "https://github.com/corretto/corretto-25/archive/refs/tags/25.0.0.36.2.tar.gz"
+    source-sha256 = "ac3d48650813180ec15deb1ac1fdc0e946c5e273447b87e62a1a15b8f66bae70"
     stacks = ["*"]
-    uri = "https://corretto.aws/downloads/resources/24.0.2.12.1/amazon-corretto-24.0.2.12.1-linux-aarch64.tar.gz"
-    version = "24.0.2"
+    uri = "https://corretto.aws/downloads/resources/25.0.0.36.2/amazon-corretto-25.0.0.36.2-linux-aarch64.tar.gz"
+    version = "25.0.0"
 
     [[metadata.dependencies.licenses]]
       type = "GPL-2.0 WITH Classpath-exception-2.0"


### PR DESCRIPTION
Removes Java 24 which has gone EOL upstream and replaces it with Java 25.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
